### PR TITLE
Adding Mysql Encryption Options

### DIFF
--- a/yoyo/backends.py
+++ b/yoyo/backends.py
@@ -620,6 +620,25 @@ class MySQLBackend(DatabaseBackend):
             kwargs["port"] = dburi.port
         if "unix_socket" in dburi.args:
             kwargs["unix_socket"] = dburi.args["unix_socket"]
+        if "ssl" in dburi.args:
+            kwargs["ssl"] = dict()
+            
+            if "sslca" in dburi.args:
+                kwargs["ssl"]["ca"] = dburi.args["sslca"]
+                
+            if "sslcapath" in dburi.args:
+                kwargs["ssl"]["capath"] = dburi.args["sslcapath"]
+                
+            if "sslcert" in dburi.args:
+                kwargs["ssl"]["cert"] = dburi.args["sslcert"]
+                
+            if "sslkey" in dburi.args:
+                kwargs["ssl"]["key"] = dburi.args["sslkey"]
+            
+            if "sslcipher" in dburi.args:
+                kwargs["ssl"]["cipher"] = dburi.args["sslcipher"]
+            
+            
         kwargs["db"] = dburi.database
         return self.driver.connect(**kwargs)
 


### PR DESCRIPTION
pymysql supports various MySQL/MariaDB encryption options. This allows
those things
to be specified as query args in the uri string.

This is useful to support technologies like RDS which often need to be
connected to over the public internet and where the proper way to do so
is to utilize TLS enable connections
(https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MariaDB.html#MariaDB.Concepts.SSLSupport)

Using "?ssl=yes&sslca=/path/to/cert" should in theory allow you to
utilize. Note that I think the "yes" part is optional.

In theory this should allow people to use mutual TLS and other
methodologies to connect to their Mysql/Mariadb Databases.